### PR TITLE
feat(likes): add post like/unlike with count + liked meta and minimal…

### DIFF
--- a/backend/src/modules/likes/like.model.js
+++ b/backend/src/modules/likes/like.model.js
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+
+const likeSchema = new mongoose.Schema(
+  {
+    postId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Post',
+      required: true,
+    },
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+  },
+  { timestamps: { createdAt: true, updatedAt: false } }
+);
+
+
+likeSchema.index({ postId: 1, userId: 1 }, { unique: true });
+likeSchema.index({ postId: 1 });
+
+const Like = mongoose.model('Like', likeSchema);
+export default Like;

--- a/backend/src/modules/likes/like.service.js
+++ b/backend/src/modules/likes/like.service.js
@@ -1,0 +1,42 @@
+import mongoose from 'mongoose';
+import Like from './like.model.js';
+import Post from '../posts/post.model.js';
+
+export const ensurePostExists = async (postId) => {
+  if (!mongoose.isValidObjectId(postId)) {
+    const err = new Error('Invalid post id');
+    err.status = 400;
+    throw err;
+  }
+  const exists = await Post.exists({ _id: postId });
+  if (!exists) {
+    const err = new Error('Post not found');
+    err.status = 404;
+    throw err;
+  }
+};
+
+export const likePost = async (postId, userId) => {
+  await ensurePostExists(postId);
+  await Like.updateOne(
+    { postId, userId },
+    { $setOnInsert: { postId, userId } },
+    { upsert: true }
+  );
+  return { ok: true };
+};
+
+export const unlikePost = async (postId, userId) => {
+  await ensurePostExists(postId);
+  await Like.deleteOne({ postId, userId });
+  return { ok: true };
+};
+
+export const getLikeMeta = async (postId, userId) => {
+  await ensurePostExists(postId);
+  const [likeCount, mine] = await Promise.all([
+    Like.countDocuments({ postId }),
+    userId ? Like.exists({ postId, userId }) : Promise.resolve(null),
+  ]);
+  return { likeCount, liked: !!mine };
+};

--- a/backend/src/modules/posts/post.controller.js
+++ b/backend/src/modules/posts/post.controller.js
@@ -1,5 +1,6 @@
 import { createCtrl } from '../../utils/controllerFactory.js';
 import * as postService from './post.service.js';
+import * as likeService from '../likes/like.service.js';
 
 const mapCover = (file) =>
   file
@@ -73,3 +74,20 @@ export const deletePostCtrl = createCtrl(
   (_b, params, _q, req) => postService.deletePost(params.id, req.user.id),
   204
 );
+
+export const likePostCtrl = createCtrl(async (_b, params, _q, req) => {
+  const { id: postId } = params;
+  await likeService.likePost(postId, req.user.id);
+  return { ok: true };
+});
+
+export const unlikePostCtrl = createCtrl(async (_b, params, _q, req) => {
+  const { id: postId } = params;
+  await likeService.unlikePost(postId, req.user.id);
+  return { ok: true };
+});
+
+export const likeMetaCtrl = createCtrl(async (_b, params, _q, req) => {
+  const { id: postId } = params;
+  return likeService.getLikeMeta(postId, req.user?.id);
+});

--- a/backend/src/modules/posts/post.routes.js
+++ b/backend/src/modules/posts/post.routes.js
@@ -5,6 +5,9 @@ import {
   getPostCtrl,
   updatePostCtrl,
   deletePostCtrl,
+  likePostCtrl,
+  unlikePostCtrl,
+  likeMetaCtrl,
 } from './post.controller.js';
 import { protect } from '../../middleware/auth.js';
 import { uploadCover } from '../../middleware/upload.js';
@@ -18,5 +21,9 @@ router.get('/:id', optionalAuth, getPostCtrl);
 router.post('/', protect, uploadCover, createPostCtrl);
 router.put('/:id', protect, uploadCover, updatePostCtrl);
 router.delete('/:id', protect, deletePostCtrl);
+router.get('/:id/like/meta', optionalAuth, likeMetaCtrl);
+
+router.put('/:id/like', protect, likePostCtrl);
+router.delete('/:id/like', protect, unlikePostCtrl);
 
 export default router;

--- a/client/src/components/Posts/LikeButton.jsx
+++ b/client/src/components/Posts/LikeButton.jsx
@@ -1,0 +1,48 @@
+
+import { Heart } from 'lucide-react';
+import { usePosts, usePostActions } from '../../hooks/usePosts';
+
+export default function LikeButton({
+  postId,
+  liked = false,
+  likeCount = 0,
+  size = 'sm', 
+  className = '',
+}) {
+  const { isToggling } = usePosts();
+  const { toggleLike } = usePostActions();
+  const busy = isToggling(postId);
+
+  const handleClick = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!postId || busy) return;
+    toggleLike(postId, !!liked); 
+  };
+
+  const pad  = size === 'sm' ? 'px-2 py-1'   : 'px-3 py-1.5';
+  const gap  = size === 'sm' ? 'gap-1.5'     : 'gap-2';
+  const icon = size === 'sm' ? 'w-4 h-4'     : 'w-5 h-5';
+  const text = size === 'sm' ? 'text-xs'     : 'text-sm';
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={busy}
+      aria-pressed={liked}
+      title={liked ? 'Beğeniyi kaldır' : 'Beğen'}
+      className={`inline-flex items-center ${gap} rounded-full ${pad}
+        transition-all hover:bg-rose-100 cursor-pointer active:scale-[0.98]
+        disabled:opacity-50 ${className}`}
+    >
+      <Heart
+        className={`${icon} transition-colors
+          ${liked ? 'text-rose-600 fill-current' : 'text-gray-500 hover:text-gray-700'}`}
+      />
+      <span className={`${text} ${liked ? 'text-rose-700' : 'text-gray-700'}`}>
+        {Number.isFinite(likeCount) ? likeCount : 0}
+      </span>
+    </button>
+  );
+}

--- a/client/src/components/Posts/PostCard.jsx
+++ b/client/src/components/Posts/PostCard.jsx
@@ -1,56 +1,87 @@
 import { Link } from 'react-router-dom';
-import { CalendarDays, User as UserIcon } from 'lucide-react';
+import { CalendarDays, UserIcon } from 'lucide-react';
 import { truncate } from '../../utils/truncate';
 import CoverPlaceholder from './CoverPlaceholder';
+import LikeButton from './LikeButton';
+import { usePostActions } from '../../hooks/usePosts';
+import { useEffect } from 'react';
 
 export default function PostCard({ post }) {
   const date = post?.createdAt ? new Date(post.createdAt) : null;
   const coverUrl = post?.cover?.url;
+  const { getPostLikeMeta } = usePostActions();
+
+  useEffect(() => {
+    if (!post?._id) return;
+    const missingCount = typeof post.likeCount !== 'number';
+    const missingLiked = typeof post.liked !== 'boolean';
+    if (missingCount || missingLiked) getPostLikeMeta(post._id);
+  }, [post?._id, getPostLikeMeta]);
 
   return (
-    <article className="bg-white border border-gray-100 rounded-2xl overflow-hidden shadow-sm hover:shadow-md transition-shadow">
-      <Link to={`/posts/${post._id}`} className="block">
+    <article className="bg-white border border-gray-100/50 rounded-3xl overflow-hidden shadow-sm backdrop-blur-sm">
+      <Link
+        to={`/posts/${post._id}`}
+        className="block relative overflow-hidden"
+      >
         {coverUrl ? (
-          <img
-            src={coverUrl}
-            alt={post.title}
-            className="w-full aspect-[16/9] object-cover"
-            loading="lazy"
-            decoding="async"
-          />
+          <div className="relative overflow-hidden">
+            <img
+              src={coverUrl || '/placeholder.svg'}
+              alt={post.title}
+              className="w-full aspect-[16/9] object-cover"
+              loading="lazy"
+              decoding="async"
+            />
+          </div>
         ) : (
-          <CoverPlaceholder title={post.title} />
+          <div className="relative">
+            <CoverPlaceholder title={post.title} />
+          </div>
         )}
       </Link>
 
-      <div className="p-5">
-        <Link to={`/posts/${post._id}`}>
-          <h3 className="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">
+      <div className="p-6 space-y-4">
+        <Link to={`/posts/${post._id}`} className="block">
+          <h3 className="text-xl font-bold text-gray-900 mb-3 line-clamp-2 leading-tight">
             {post.title}
           </h3>
         </Link>
 
-        <p className="text-gray-600 mb-4">{truncate(post.content)}</p>
+        <p className="text-gray-600 leading-relaxed text-sm">
+          {truncate(post.content)}
+        </p>
 
-        <div className="flex items-center justify-between text-sm text-gray-500">
-          <div className="flex items-center space-x-3">
-            <span className="inline-flex items-center">
-              <CalendarDays className="w-4 h-4 mr-1.5" />
-              {date ? date.toLocaleDateString('tr-TR') : '-'}
-            </span>
-            {post.author?.username && (
-              <span className="inline-flex items-center">
-                <UserIcon className="w-4 h-4 mr-1.5" />
-                {post.author.username}
-              </span>
-            )}
+        <div className="pt-5 border-t border-gray-100">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-6">
+              <div className="flex items-center text-xs text-gray-500">
+                <CalendarDays className="w-4 h-4 mr-2 text-gray-400" />
+                <span className="font-medium">
+                  {date ? date.toLocaleDateString('tr-TR') : '-'}
+                </span>
+              </div>
+
+              {post.author?.username && (
+                <div className="flex items-center text-xs text-gray-500">
+                  <UserIcon className="w-4 h-4 mr-2 text-gray-400" />
+                  <span className="font-medium">{post.author.username}</span>
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center gap-4">
+              <LikeButton
+                postId={post._id}
+                liked={!!post.liked}
+                likeCount={
+                  typeof post.likeCount === 'number' ? post.likeCount : 0
+                }
+                size="sm"
+              />
+              <Link to={`/posts/${post._id}`}>Şimdi Oku →</Link>
+            </div>
           </div>
-          <Link
-            to={`/posts/${post._id}`}
-            className="text-emerald-600 hover:text-emerald-700 font-medium"
-          >
-            Şimdi Oku →
-          </Link>
         </div>
       </div>
     </article>

--- a/client/src/hooks/usePosts.js
+++ b/client/src/hooks/usePosts.js
@@ -6,6 +6,9 @@ import {
   createNewPost,
   updatePost,
   deletePost,
+  fetchPostLikeMeta,
+  togglePostLike,
+  resetPostsState,
 } from '../features/posts/postSlice';
 
 export const usePosts = () => {
@@ -18,7 +21,10 @@ export const usePosts = () => {
     message,
     hasMore,
     nextCursor,
+    toggling,
   } = useSelector((state) => state.posts);
+
+  const isToggling = (postId) => !!toggling?.[postId];
 
   return {
     posts,
@@ -29,11 +35,13 @@ export const usePosts = () => {
     message,
     hasMore,
     nextCursor,
+    isToggling,
   };
 };
 
 export const usePostActions = () => {
   const dispatch = useDispatch();
+
   const getPost = (id) => dispatch(fetchPost(id));
   const getPosts = (params) => dispatch(fetchPosts(params));
   const createPost = (postData) => dispatch(createNewPost(postData));
@@ -41,11 +49,28 @@ export const usePostActions = () => {
     dispatch(updatePost({ id, data: postData }));
   const deleteExistingPost = (id) => dispatch(deletePost(id));
 
+  const getPostLikeMeta = (postId) => dispatch(fetchPostLikeMeta(postId));
+  const toggleLike = (postId, liked) =>
+    dispatch(togglePostLike({ postId, liked }));
+
+  const loadPostWithMeta = (postId) => {
+    return Promise.all([
+      dispatch(fetchPost(postId)),
+      dispatch(fetchPostLikeMeta(postId)),
+    ]);
+  };
+
+  const reset = () => dispatch(resetPostsState());
+
   return {
     getPost,
     getPosts,
     createPost,
     updateExistingPost,
     deleteExistingPost,
+    reset,
+    getPostLikeMeta,
+    toggleLike,
+    loadPostWithMeta,
   };
 };

--- a/client/src/services/postsService.js
+++ b/client/src/services/postsService.js
@@ -57,3 +57,30 @@ export const deletePost = async (postId) => {
   const { data } = await axiosInstance.delete(`/posts/${postId}`);
   return data;
 };
+
+/**
+ * @param {string} postId
+ * @returns {Promise<{ok: boolean}>}
+ */
+export const likePost = async (postId) => {
+  const { data } = await axiosInstance.put(`/posts/${postId}/like`);
+  return data;
+};
+
+/**
+ * @param {string} postId
+ * @returns {Promise<{ok: boolean}>}
+ */
+export const unlikePost = async (postId) => {
+  const { data } = await axiosInstance.delete(`/posts/${postId}/like`);
+  return data;
+};
+
+/**
+ * @param {string} postId
+ * @returns {Promise<{likeCount: number, liked: boolean}>}
+ */
+export const getPostLikeMeta = async (postId) => {
+  const { data } = await axiosInstance.get(`/posts/${postId}/like/meta`);
+  return data;
+};


### PR DESCRIPTION
### Summary
Add post like/unlike with `likeCount` and `liked` meta + a minimalist LikeButton.

### Changes
- Backend: like/unlike endpoints + meta (count, liked)
- Frontend: toggle thunk (optimistic + server sync), ViewPost & PostCard integration
- New `LikeButton` (icon + count)
